### PR TITLE
Config: Rename POSIX sysinfo dependency

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -5,7 +5,7 @@ menuconfig LIBGCC
 	select LIBUKALLOC
 	select LIBNEWLIBC
 	select LIBUKMMAP
-	select UKSYSINFO
+	select LIBPOSIX_SYSINFO
 
 if LIBGCC
 


### PR DESCRIPTION
Rename `UKSYSINFO` to `LIBPOSIX_SYSINFO`.