### PR TITLE
Correct license headers introduced by NEC Laboratories Europe GmbH

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -33,8 +33,6 @@
 #  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 #  POSSIBILITY OF SUCH DAMAGE.
 #
-#  THIS HEADER MAY NOT BE EXTRACTED OR MODIFIED IN ANY WAY.
-#
 
 ################################################################################
 # Library registration


### PR DESCRIPTION
This commit removes the additional clause
"THIS HEADER MAY NOT BE EXTRACTED OR MODIFIED IN ANY WAY"
from BSD license headers that got introduced by mistake
with the following commits:
 0a8e780 - Add Makefile.uk (Charalampos Mainas)

On the one hand, this additional clause is redundant because
the BSD license already states that it must remain and the
copyright notice must be kept.
On the other hand, the clause freezes the file header
and prohibits future contributors from extending the
copyright notice for their contributions. This additional
clause is not part of the official BSD 3-clause.

The original author(s) or an authorized representative from
the author's affiliation consents to the change with a
`Reviewed-by` tag to this commit.

Signed-off-by: Simon Kuenzer <simon.kuenzer@neclab.eu>
