### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "gcc"
+description := "An optimizing compiler produced by the GNU Project supporting various programming languages, hardware architectures and operating systems."
+gitrepo     := "git://gcc.gnu.org/git/gcc.git"
+homepage    := "https://gcc.gnu.org/"
+version     := 7.3.0 sha256:fa06e455ca198ddc11ea4ddf2a394cf7cfb66aa7e0ab98cc1184189f1d405870 https://ftp.gnu.org/gnu/gcc/gcc-7.3.0/gcc-7.3.0.tar.gz
+license     := "GPL-3.0-with-GCC-exception"


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

